### PR TITLE
Fixes nginx vhost appending backslash to first query string parameter

### DIFF
--- a/src/Template/Bake/vhost_nginx.ctp
+++ b/src/Template/Bake/vhost_nginx.ctp
@@ -20,7 +20,7 @@ server {
     error_log /var/log/nginx/:url.error.log;
 
     location / {
-        try_files $uri \$uri/ /index.php?\$args;
+        try_files $uri \$uri/ /index.php?$args;
     }
 
     location ~ \.php$ {


### PR DESCRIPTION
First query string parameter got appended with a \ causing first (e.g. Paginator) query string not to be recognized.