### PR TITLE
Moves self-update to UpdateShell

### DIFF
--- a/src/Shell/ConfigShell.php
+++ b/src/Shell/ConfigShell.php
@@ -26,14 +26,6 @@ class ConfigShell extends AppShell
         $parser = parent::getOptionParser();
         $parser->description([__('Manage various configuration settings.')]);
 
-        $parser->addSubcommand('update', [
-            'parser' => [
-                'description' => [
-                    __("Update cakebox console and management website.")
-                ],
-            ]
-        ]);
-
         $parser->addSubcommand('git', [
             'parser' => [
                 'description' => [
@@ -77,20 +69,5 @@ class ConfigShell extends AppShell
             }
         }
         $this->exitBashSuccess("Git configuration updated successfully");
-    }
-
-    /**
-     * Self-update cakebox-console repository and composer packages.
-     *
-     * @return void
-     */
-     public function update()
-    {
-        $this->out("Self-updating cakebox console and website");
-        $this->out("Please wait... this can take a moment");
-        if (!$this->execute->selfUpdate()) {
-            $this->exitBashError("Error updating application.");
-        }
-        $this->exitBashSuccess("Update completed successfully");
     }
 }

--- a/src/Shell/UpdateShell.php
+++ b/src/Shell/UpdateShell.php
@@ -1,0 +1,48 @@
+<?php
+namespace App\Shell;
+
+use Cake\Console\Shell;
+
+/**
+ * Shell class for managing software updates.
+ */
+class UpdateShell extends AppShell
+{
+
+    /**
+     * Define available subcommands, arguments and options.
+     *
+     * @return parser
+     */
+    public function getOptionParser()
+    {
+        $parser = parent::getOptionParser();
+        $parser->description([__('Manage updates.')]);
+
+        $parser->addSubcommand('self', [
+            'parser' => [
+                'description' => [
+                __("Self-updates the Cakebox Dashboard and Console commands to the most recent version")
+                ]
+            ]
+        ]);
+        return $parser;
+    }
+
+    /**
+     * Self-updates the Cakebox Dashboard and Console Commands by updating the
+     * Git repository and all underlying Composer libraries.
+     *
+     * @return void
+     */
+    public function self()
+    {
+        $this->logStart("Self-updating Cakebox Dashboard and Console Commands");
+        $this->out("Please wait... this can take a moment");
+
+        if (!$this->execute->selfUpdate()) {
+            $this->exitBashError("Error updating application.");
+        }
+        $this->exitBashSuccess("Update completed successfully");
+    }
+}

--- a/src/Shell/UpdateShell.php
+++ b/src/Shell/UpdateShell.php
@@ -23,7 +23,7 @@ class UpdateShell extends AppShell
             'parser' => [
                 'description' => [
                     __(
-                        "Self-updates your Cakebox Dashboard and Console Commands
+                        "Updates your Cakebox Dashboard and Cakebox Commands
                         to the most recent version."
                     )
                 ]
@@ -33,14 +33,14 @@ class UpdateShell extends AppShell
     }
 
     /**
-     * Self-updates the Cakebox Dashboard and Console Commands by updating the
-     * Git repository and all underlying Composer libraries.
+     * Self-updates the Cakebox Dashboard and Shell commands by updating the
+     * cakebox-console Git repository and ALL underlying Composer libraries.
      *
      * @return void
      */
     public function self()
     {
-        $this->logStart("Self-updating Cakebox Dashboard and Console Commands");
+        $this->logStart("Updating Cakebox Dashboard and Cakebox Commands");
         $this->out("Please wait... this can take a moment");
 
         if (!$this->execute->selfUpdate()) {

--- a/src/Shell/UpdateShell.php
+++ b/src/Shell/UpdateShell.php
@@ -22,7 +22,10 @@ class UpdateShell extends AppShell
         $parser->addSubcommand('self', [
             'parser' => [
                 'description' => [
-                __("Self-updates the Cakebox Dashboard and Console commands to the most recent version")
+                    __(
+                        "Self-updates your Cakebox Dashboard and Console Commands
+                        to the most recent version."
+                    )
                 ]
             ]
         ]);


### PR DESCRIPTION
Moves the self-update command from `cakebox config update` to `cakebox update self`.

Should feel more natural to users and caters for possible future functionality like updating the global PHPCS and CakePHP codesniffer.