### PR TITLE
Removes bootstrap-ui due to limiting Dashboard functionality

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
 		"cakephp/cakephp": "3.0.*-dev",
 		"cakephp/debug_kit": "3.0.*-dev",
 		"cakephp/plugin-installer": "*",
-		"friendsofcake/bootstrap-ui": "master",
 		"mobiledetect/mobiledetectlib": "2.*",
 		"monolog/monolog": "master"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "0f4b42397836e57ea00645e3716252c3",
+    "hash": "e594afee34a3f91a41fc32bfab1c9873",
     "packages": [
         {
             "name": "aura/installer-default",
@@ -131,12 +131,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/bake.git",
-                "reference": "f0211df164af2b68f64bd5e0857b99166406ef2b"
+                "reference": "0adfe6f2004eb2c7f6c55a4af01bcea57aa1c933"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/bake/zipball/f0211df164af2b68f64bd5e0857b99166406ef2b",
-                "reference": "f0211df164af2b68f64bd5e0857b99166406ef2b",
+                "url": "https://api.github.com/repos/cakephp/bake/zipball/0adfe6f2004eb2c7f6c55a4af01bcea57aa1c933",
+                "reference": "0adfe6f2004eb2c7f6c55a4af01bcea57aa1c933",
                 "shasum": ""
             },
             "require": {
@@ -169,7 +169,7 @@
                 "bake",
                 "cakephp"
             ],
-            "time": "2015-02-26 02:40:26"
+            "time": "2015-03-05 06:45:14"
         },
         {
             "name": "cakephp/cakephp",
@@ -177,12 +177,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/cakephp.git",
-                "reference": "dbb748b4757e9fd0a44611648d4ad5150669be40"
+                "reference": "c644474f9965f020483f489b90643c4266c3f83b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/cakephp/zipball/dbb748b4757e9fd0a44611648d4ad5150669be40",
-                "reference": "dbb748b4757e9fd0a44611648d4ad5150669be40",
+                "url": "https://api.github.com/repos/cakephp/cakephp/zipball/c644474f9965f020483f489b90643c4266c3f83b",
+                "reference": "c644474f9965f020483f489b90643c4266c3f83b",
                 "shasum": ""
             },
             "require": {
@@ -237,7 +237,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2015-02-27 06:50:15"
+            "time": "2015-03-11 01:35:27"
         },
         {
             "name": "cakephp/debug_kit",
@@ -245,12 +245,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/debug_kit.git",
-                "reference": "ac1f6cdb8b659fb5044fb01e38817667149f822d"
+                "reference": "1ff614286eb9d9c4c6066e76add0987ec22ca563"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/debug_kit/zipball/ac1f6cdb8b659fb5044fb01e38817667149f822d",
-                "reference": "ac1f6cdb8b659fb5044fb01e38817667149f822d",
+                "url": "https://api.github.com/repos/cakephp/debug_kit/zipball/1ff614286eb9d9c4c6066e76add0987ec22ca563",
+                "reference": "1ff614286eb9d9c4c6066e76add0987ec22ca563",
                 "shasum": ""
             },
             "require": {
@@ -294,7 +294,7 @@
                 "debug",
                 "kit"
             ],
-            "time": "2015-02-25 02:50:12"
+            "time": "2015-03-03 02:05:09"
         },
         {
             "name": "cakephp/plugin-installer",
@@ -335,56 +335,6 @@
             ],
             "description": "A composer installer for CakePHP 3.0+ plugins.",
             "time": "2015-02-06 02:06:07"
-        },
-        {
-            "name": "friendsofcake/bootstrap-ui",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/FriendsOfCake/bootstrap-ui.git",
-                "reference": "68d3ed7e81bf09581c6c33f42ef40c7c4aff1e79"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfCake/bootstrap-ui/zipball/68d3ed7e81bf09581c6c33f42ef40c7c4aff1e79",
-                "reference": "68d3ed7e81bf09581c6c33f42ef40c7c4aff1e79",
-                "shasum": ""
-            },
-            "require": {
-                "cakephp/cakephp": "3.0.*-dev"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "4.1.*"
-            },
-            "type": "cakephp-plugin",
-            "autoload": {
-                "psr-4": {
-                    "BootstrapUI\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jad Bitar",
-                    "homepage": "http://jadb.io",
-                    "role": "Author"
-                },
-                {
-                    "name": "Others",
-                    "homepage": "https://github.com/friendsofcake/bootstrap-ui/graphs/contributors"
-                }
-            ],
-            "description": "Twitter Bootstrap 3 support for CakePHP 3",
-            "homepage": "http://github.com/friendsofcake/bootstrap-ui",
-            "keywords": [
-                "bootstrap",
-                "cakephp",
-                "twitter"
-            ],
-            "time": "2015-02-26 03:55:52"
         },
         {
             "name": "ircmaxell/password-compat",
@@ -430,22 +380,23 @@
         },
         {
             "name": "mobiledetect/mobiledetectlib",
-            "version": "2.8.11",
+            "version": "2.8.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/serbanghita/Mobile-Detect.git",
-                "reference": "c68901fb09227dcf04872f0d6a27b9f6e75ecf1f"
+                "reference": "af30b5b7bd683f575b1c56f74e0e0632f5dd9fc9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/serbanghita/Mobile-Detect/zipball/c68901fb09227dcf04872f0d6a27b9f6e75ecf1f",
-                "reference": "c68901fb09227dcf04872f0d6a27b9f6e75ecf1f",
+                "url": "https://api.github.com/repos/serbanghita/Mobile-Detect/zipball/af30b5b7bd683f575b1c56f74e0e0632f5dd9fc9",
+                "reference": "af30b5b7bd683f575b1c56f74e0e0632f5dd9fc9",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.0.0"
             },
             "require-dev": {
+                "codeclimate/php-test-reporter": "dev-master",
                 "johnkary/phpunit-speedtrap": "~1.0@dev",
                 "phpunit/phpunit": "*"
             },
@@ -479,7 +430,7 @@
                 "mobile detector",
                 "php mobile detect"
             ],
-            "time": "2014-11-23 13:08:17"
+            "time": "2015-03-11 10:02:22"
         },
         {
             "name": "monolog/monolog",
@@ -487,12 +438,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "bba433ac380c47523fab495a1322368381df0996"
+                "reference": "c31a2c4e8db5da8b46c74cf275d7f109c0f249ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/bba433ac380c47523fab495a1322368381df0996",
-                "reference": "bba433ac380c47523fab495a1322368381df0996",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c31a2c4e8db5da8b46c74cf275d7f109c0f249ac",
+                "reference": "c31a2c4e8db5da8b46c74cf275d7f109c0f249ac",
                 "shasum": ""
             },
             "require": {
@@ -509,6 +460,7 @@
                 "phpunit/phpunit": "~4.0",
                 "raven/raven": "~0.5",
                 "ruflin/elastica": "0.90.*",
+                "swiftmailer/swiftmailer": "~5.3",
                 "videlalvaro/php-amqplib": "~2.4"
             },
             "suggest": {
@@ -525,7 +477,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12.x-dev"
+                    "dev-master": "1.13.x-dev"
                 }
             },
             "autoload": {
@@ -551,7 +503,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2015-02-25 16:48:53"
+            "time": "2015-03-09 09:58:04"
         },
         {
             "name": "nesbot/carbon",

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -174,8 +174,6 @@ Request::addDetector('tablet', function ($request) {
 if (Configure::read('debug')) {
 //	Plugin::load('DebugKit', ['bootstrap' => true]);
 }
-Plugin::load('BootstrapUI');
-
 
 /**
 * Connect middleware/dispatcher filters.

--- a/src/Template/Applications/index.ctp
+++ b/src/Template/Applications/index.ctp
@@ -45,43 +45,16 @@
 	</div> <!-- /widget -->
 </div> <!-- col-sm-10 -->
 
-<!-- Actions -->
+<!-- Stats -->
 <div class="col-sm-2 column">
-	<div class="actions">
-		<a href="#" class="todo btn btn-primary btn-block"><?= __('New Application') ?></a>
-	</div>
-</div>
+	<div class="widget stacked widget-table action-table">
+		<div class="widget-header">
+			<i class="fa fa-star"></i>
+			<h3><?= __('Stats') ?></h3>
+		</div>
 
-<!-- Modal -->
-<div class="modal fade" id="fileModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-	<div class="modal-dialog">
-		<div class="modal-content">
-			<div class="modal-header">
-				<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-				<h4 class="modal-title" id="myModalLabel">ajax-loaded-title</h4>
-			</div>
-			<div class="modal-body">
-				ajax-loaded-content
-			</div>
-			<div class="modal-footer">
-				<button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-			</div>
+		<div class="widget-content">
+			<div class="panel-body">
 		</div>
 	</div>
 </div>
-
-<script>
-$('#fileModal').on('show.bs.modal', function (event) {
-	var modal = $(this)
-	var button = $(event.relatedTarget) // Button that triggered the modal
-	var filename = button.closest('tr').find('td.filename').html()
-	$('.modal-title').html('/etc/nginx/sites-available/' + filename)
-	var jqxhr = $.getJSON( 'sitefiles/file/' + filename + '.json', function(data) {
-		console.log(modal)
-		modal.find('.modal-body').html('<pre>' + data.content + '</pre>')
-	})
-})
-.fail(function() {
-	alert( 'So sorry, something went wrong fetching the file...' )
-})
-</script>

--- a/src/Template/Databases/index.ctp
+++ b/src/Template/Databases/index.ctp
@@ -44,9 +44,16 @@
 	</div> <!-- /widget -->
 </div> <!-- col-sm-10 -->
 
-<!-- Actions -->
+<!-- Stats -->
 <div class="col-sm-2 column">
-	<div class="actions">
-		<a href="#" class="todo btn btn-primary btn-block"><?= __('New Database') ?></a>
+	<div class="widget stacked widget-table action-table">
+		<div class="widget-header">
+			<i class="fa fa-star"></i>
+			<h3><?= __('Stats') ?></h3>
+		</div>
+
+		<div class="widget-content">
+			<div class="panel-body">
+		</div>
 	</div>
 </div>

--- a/src/Template/SiteFiles/index.ctp
+++ b/src/Template/SiteFiles/index.ctp
@@ -64,10 +64,17 @@ use App\Form\SiteFileForm;
 
 </div> <!-- col-sm-10 -->
 
-<!-- Actions -->
+<!-- Stats -->
 <div class="col-sm-2 column">
-	<div class="actions">
-		<a href="#" class="ajax-form-modal btn btn-primary btn-block" data-target="#formModalAdd"><?= __('New Virtual Host') ?></a>
+	<div class="widget stacked widget-table action-table">
+		<div class="widget-header">
+			<i class="fa fa-star"></i>
+			<h3><?= __('Stats') ?></h3>
+		</div>
+
+		<div class="widget-content">
+			<div class="panel-body">
+		</div>
 	</div>
 </div>
 
@@ -84,44 +91,6 @@ use App\Form\SiteFileForm;
 			</div>
 			<div class="modal-footer">
 				<button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-			</div>
-		</div>
-	</div>
-</div>
-
-
-<!-- Form Modal -->
-<div class="modal fade" id="formModalAdd" tabindex="-1" role="dialog" aria-hidden="true">
-	<div class="modal-dialog">
-		<div class="modal-content">
-			<div class="modal-header">
-				<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-				<h4 class="modal-title"><?= __('New Nginx website') ?></h4>
-			</div>
-			<div class="modal-body">
-				<?php
-					$form = new SiteFileForm();
-					echo $this->Form->create($form, [
-						'url' => ['controller' => 'sitefiles', 'action' => 'ajax_add.json']
-					]);
-				?>
-
-				<div class="alert alert-danger alert-dismissible collapse" role="alert">
-					<button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-					<span>
-						ajax-loaded error message
-					</span>
-				</div>
-				<?php
-					echo $this->Form->input('url');
-					echo $this->Form->input('webroot');
-					echo $this->Form->input('force');
-					echo $this->Form->end();
-				?>
-			</div>
-			<div class="modal-footer">
-				<button type="button" class="btn btn-default" data-dismiss="modal"><?= __('Cancel') ?></button>
-				<button type="button" id="form-submit" class="btn btn-primary"><?= __('Submit') ?></button>
 			</div>
 		</div>
 	</div>

--- a/src/View/AppView.php
+++ b/src/View/AppView.php
@@ -24,15 +24,14 @@ class AppView extends View {
 /**
  * Initialization hook method.
  *
- * For e.g. use this method to load a helper for all views:
+ * Use this method to load a helper for all views, e.g.
  * `$this->loadHelper('Html');`
+ * `$this->loadHelper('Flash', ['className' => 'BootstrapUI.Flash']);`
  *
  * @return void
  */
 	public function initialize()
 	{
-		$this->loadHelper('Form', ['className' => 'BootstrapUI.Form']);
-		$this->loadHelper('Flash', ['className' => 'BootstrapUI.Flash']);
 	}
 
 }


### PR DESCRIPTION
This change replaces the ``New`` buttons with a ``Stats`` widget until a suitable solution for form-handling and shelling/scheduling tasks has been found.

Until then adding applications, websites, databases, etc should be done using the Cakebox Commands.