### PR TITLE
Adds cakebox backup command and fixes broken Virtual Hosts page on Linux.

### DIFF
--- a/src/Lib/CakeboxExecute.php
+++ b/src/Lib/CakeboxExecute.php
@@ -681,7 +681,6 @@ class CakeboxExecute
         if ($this->shell("mv $tempFolder $targetFolder", 'root') == false) {
             return false;
         }
-
         return true;
     }
 

--- a/src/Lib/CakeboxExecute.php
+++ b/src/Lib/CakeboxExecute.php
@@ -2,8 +2,10 @@
 namespace App\Lib;
 
 use Cake\Cache\Cache;
+use Cake\Core\Exception\Exception;
 use Cake\Datasource\ConnectionManager;
 use Cake\Filesystem\File;
+use Cake\I18n\Time;
 use Cake\Log\Log;
 use Cake\Utility\String;
 
@@ -636,6 +638,49 @@ class CakeboxExecute
         $bootstrapFile = $appdir . DS . "app" . DS . "Config" . DS . "bootstrap.php";
         $fh = new File($bootstrapFile);
         $fh->append('CakePlugin::loadAll();');
+
+        return true;
+    }
+
+    /**
+     * Creates a Percona XtraBackup (hot) backup of the MySQL server in
+     * /tmp before moving it to the Vagrant Synced folder /cakebox/backups
+     * (to prevent speed issues on systems with slow synced folders).
+     *
+     * @return boolean Success if the backup completes succesfully
+     * @throws Cake\Core\Exception\Exception
+     */
+
+    public function backupDatabases()
+    {
+        // determine paths
+        $this->_log("Determining backup folders");
+
+        $timestamp = (new Time)->now()->i18nFormat('YYYY-MM-dd-HH-mm-ss');
+        $tempFolder = "/tmp/$timestamp";
+        $this->_log("* Temporary folder => $tempFolder");
+
+        $targetFolder = '/cakebox/backups/mysql/';
+        if (!file_exists($targetFolder)) {
+            $this->_log("* Creating database backup root folder $targetFolder");
+            if (!mkdir($targetFolder)) {
+                return false;
+            };
+        }
+        $targetFolder .= (new Time)->now()->i18nFormat('YYYY-MM-dd-HH-mm-ss');
+        $this->_log("* Destination folder => $targetFolder");
+
+        // shell Percona XtraBackup job as root
+        $this->_log("Starting hot backup");
+        if ($this->shell("xtrabackup --backup --target-dir=$tempFolder", 'root') == false) {
+            return false;
+        }
+
+        // move backup from /tmp to synced folder
+        $this->_log("Moving backup to Synced Folder");
+        if ($this->shell("mv $tempFolder $targetFolder", 'root') == false) {
+            return false;
+        }
 
         return true;
     }

--- a/src/Shell/BackupShell.php
+++ b/src/Shell/BackupShell.php
@@ -1,0 +1,50 @@
+<?php
+namespace App\Shell;
+
+use Cake\Console\Shell;
+
+/**
+ * Shell class for managing software updates.
+ */
+class BackupShell extends AppShell
+{
+
+    /**
+     * Define available subcommands, arguments and options.
+     *
+     * @return parser
+     */
+    public function getOptionParser()
+    {
+        $parser = parent::getOptionParser();
+        $parser->description([__('Manage backups.')]);
+
+        $parser->addSubcommand('database', [
+            'parser' => [
+                'description' => [
+                    __(
+                        "Creates a Percona XtraBackup full (hot) backup of your MySQL server."
+                    )
+                ]
+            ]
+        ]);
+        return $parser;
+    }
+
+    /**
+     * Creates a Percona XtraBackup (hot) full backup of the MySQL server
+     * in the Vagrant Synced folder /cakebox/backups (inside the box).
+     *
+     * @return void
+     */
+    public function database()
+    {
+        $this->logStart("Creating full (hot) backup of your MySQL server");
+        $this->out("Please wait... this can take a moment");
+
+        if (!$this->execute->backupDatabases()) {
+            $this->exitBashError("Error creating backup.");
+        }
+        $this->exitBashSuccess("Backups created successfully.");
+    }
+}

--- a/src/Shell/ConfigShell.php
+++ b/src/Shell/ConfigShell.php
@@ -10,13 +10,6 @@ class ConfigShell extends AppShell
 {
 
     /**
-     * @var array Shell Tasks used by this shell.
-     */
-#    public $tasks = [
-#        'Exec'
-#    ];
-
-    /**
      * Define available subcommands, arguments and options.
      *
      * @return parser

--- a/src/Template/Dashboards/index.ctp
+++ b/src/Template/Dashboards/index.ctp
@@ -151,7 +151,7 @@ $this->Html->script('cdn-fallback/jquery-plugins/flot/jquery.flot.resize.min', [
 					// Site files
 					echo $this->Html->link(
 						'<i class="shortcut-icon fa fa-file-text-o"></i><span class="shortcut-label"></span>' . __('Virtual Hosts'),
-						['controller' => 'Sitefiles', 'action' => 'index'],
+						['controller' => 'SiteFiles', 'action' => 'index'],
 						['class' => 'shortcut', 'escape' => false]
 					);
 

--- a/src/Template/Dashboards/usage.ctp
+++ b/src/Template/Dashboards/usage.ctp
@@ -25,14 +25,15 @@
                                 inside your virtual machine to create databases, virtual hosts and applications.
                             </p>
                             <ul>
-                                <li><i class="fa fa-arrow-right"></i><em>cakebox application --help</em></li>
+                                <li><i class="fa fa-arrow-right"></i><em>cakebox --help</em></li>
                                 <li><i class="fa fa-arrow-right"></i><em>cakebox site --help</em></li>
                                 <li><i class="fa fa-arrow-right"></i><em>cakebox database --help</em></li>
+                                <li><i class="fa fa-arrow-right"></i><em>cakebox application --help</em></li>
                             </ul>
                         </div>
                     </li>
 
-                    <!-- Self-Update -->
+                    <!-- Updates -->
                     <li id="faq-2">
                         <div class="faq-icon">
                             <div class="faq-number">2</div>
@@ -40,7 +41,7 @@
                         <div class="faq-text">
                             <h4><?= __("Updates") ?></h4>
                             <p>
-                                Update your Cakebox Dashboard and Commands by running
+                                Self-update your Cakebox Dashboard and Cakebox Commands by running
                                 <?php
                                     echo $this->Html->link('cakebox update self', 'http://cakebox.readthedocs.org/en/latest/tutorials/updating-your-box/')
                                 ?>
@@ -49,19 +50,36 @@
                         </div>
                     </li>
 
-                    <!-- YAML re-provisioning -->
+                    <!-- Backups -->
                     <li id="faq-3">
                         <div class="faq-icon">
                             <div class="faq-number">3</div>
                         </div>
                         <div class="faq-text">
+                            <h4><?= __("Backups") ?></h4>
+                            <p>
+                                Create hot backups of your database server by running
+                                <?php
+                                    echo $this->Html->link('cakebox backup database', 'http://cakebox.readthedocs.org/en/latest/tutorials/updating-your-box/')
+                                ?>
+                                inside your box.
+                            </p>
+                        </div>
+                    </li>
+
+                    <!-- Provisioning -->
+                    <li id="faq-4">
+                        <div class="faq-icon">
+                            <div class="faq-number">4</div>
+                        </div>
+                        <div class="faq-text">
                             <h4><?= __("Provisioning") ?></h4>
                             <p>
-                                Use the
+                                Your
                                 <?php
                                     echo $this->Html->link('Cakebox.yaml', 'http://cakebox.readthedocs.org/en/latest/usage/cakebox-yaml/')
                                 ?>
-                                file so you will be able to (re)create exact copies of your box without losing your:
+                                file enables you to (re)create exact copies of your box without losing your:
                             </p>
                             <ul>
                                 <li><li><i class="fa fa-arrow-right"></i>virtual machine settings (hostname, IP address, CPUs, memory)</li>
@@ -77,15 +95,15 @@
                         </div>
                     </li>
 
-                    <!-- Vagrant Commands -->
-                    <li id="faq-4">
+                    <!-- Vagrant CLI -->
+                    <li id="faq-5">
                         <div class="faq-icon">
-                            <div class="faq-number">4</div>
+                            <div class="faq-number">5</div>
                         </div>
                         <div class="faq-text">
                             <h4><?= __("Vagrant Commands") ?></h4>
                             <p>
-                                Your box lives inside a Vagrant virtual machine so get to know the
+                                Your box lives is a Vagrant virtual machine so get familiar with the
                                 <?php
                                     echo $this->Html->link('Vagrant CLI', 'https://docs.vagrantup.com/v2/cli/index.html')
                                 ?>

--- a/webroot/js/pages/site_files.js
+++ b/webroot/js/pages/site_files.js
@@ -26,7 +26,7 @@ $( document ).ready(function() {
 		var button = $(event.relatedTarget) // Button that triggered the modal
 		var filename = button.closest('tr').find('td.filename').html()
 		$('.modal-title').html('/etc/nginx/sites-available/' + filename)
-		var jqxhr = $.getJSON( 'site_files/file/' + filename + '.json', function(data) {
+		var jqxhr = $.getJSON( 'sitefiles/file/' + filename + '.json', function(data) {
 			console.log(modal)
 			modal.find('.modal-body').html('<pre>' + data.content + '</pre>')
 		})


### PR DESCRIPTION
## New Cakebox Command

This PR adds the ``cakebox backup database`` command:

+ used for creating full (hot) backups of the MySQL server
+ inside the virtual machine the backups can be found in folder ``/cakebox/backups/mysql``
+ on your local machine the backups can be found in the ``.cakebox/backups/mysql`` subfolder inside your ``cakebox`` root folder