### PR TITLE
Fixes self-install by using composer install to update vendor libraries (instead of update)

### DIFF
--- a/src/Lib/CakeboxExecute.php
+++ b/src/Lib/CakeboxExecute.php
@@ -182,7 +182,7 @@ class CakeboxExecute
         }
 
         Log::debug("* Updating composer packages");
-        $command = 'cd /cakebox/console; composer update --prefer-dist --no-dev';
+        $command = 'cd /cakebox/console; composer install --prefer-dist --no-dev';
         if (!$this->shell($command, 'vagrant')) {
             return false;
         }


### PR DESCRIPTION
Only use install to update vendor libraries according to current composer.lock file

Using update will ignore the lock file.