### PR TITLE
Adds --repair option to cakebox application command to fix (re)provisioning apps with existing sources

### DIFF
--- a/src/Lib/CakeboxExecute.php
+++ b/src/Lib/CakeboxExecute.php
@@ -133,10 +133,10 @@ class CakeboxExecute
     public function mkVagrantDir($path)
     {
         $this->flushLogs();
-        if ($this->shell("mkdir $path", 'root') == false) {
+        if (!$this->shell("mkdir $path", 'root')) {
             return false;
         }
-        if ($this->shell("chown vagrant $path -R", 'root') == false) {
+        if (!$this->shell("chown vagrant $path -R", 'root')) {
             return false;
         }
         return true;
@@ -202,7 +202,7 @@ class CakeboxExecute
     {
         $this->flushLogs();
         $command = "composer create-project --prefer-dist --no-interaction -s dev $package $path";
-        if ($this->shell($command, 'vagrant') == false) {
+        if (!$this->shell($command, 'vagrant')) {
             return false;
         }
         return true;
@@ -218,7 +218,7 @@ class CakeboxExecute
     {
         $this->flushLogs();
         $command = "cd $directory; composer install --prefer-dist --no-interaction";
-        if ($this->shell($command, 'vagrant') == false) {
+        if (!$this->shell($command, 'vagrant')) {
             return false;
         }
         return true;
@@ -246,7 +246,7 @@ class CakeboxExecute
         }
 
         # Execute git clone
-        if ($this->shell("git clone $repository $path", 'vagrant') == false) {
+        if (!$this->shell("git clone $repository $path", 'vagrant')) {
             return false;
         }
         return true;
@@ -261,7 +261,7 @@ class CakeboxExecute
         $this->_log("Sanity checking SSH before attempting git clone");
 
         $this->_log("* Sanity checking SSH Agent forwarded SSH key");
-        if ($this->shell("ssh-add -l", 'vagrant') == false) {
+        if (!$this->shell("ssh-add -l", 'vagrant')) {
             $this->_error("Error: SSH git clone requires a SSH key, none found");
             $this->_log(" => Note: make sure your SSH agent is forwarding the required identity key if this is a private repository");
             $this->_log(" => Note: Windows users MUST use Pageant or SSH Agent Forwarding will simply not work");
@@ -269,7 +269,7 @@ class CakeboxExecute
         }
 
         $this->_log("* Sanity checking Github user.name");
-        if ($this->shell("git config user.name", 'vagrant') == false) {
+        if (!$this->shell("git config user.name", 'vagrant')) {
             return false;
         }
         return true;
@@ -285,12 +285,12 @@ class CakeboxExecute
         $this->_log("Reloading Nginx webserver");
 
         $this->_log("* Checking configuration");
-        if ($this->shell("nginx -t", 'root') == false) {
+        if (!$this->shell("nginx -t", 'root')) {
             return false;
         }
 
         $this->_log("* Restarting service");
-        if ($this->shell("service nginx reload", 'root') == false) {
+        if (!$this->shell("service nginx reload", 'root')) {
             return false;
         }
         return true;
@@ -320,7 +320,7 @@ class CakeboxExecute
         $siteFile = $this->cbi->webserverMeta['nginx']['sites-available'] . DS . $url;
         $this->_log("Creating virtual host file for $url");
         if (file_exists($siteFile)) {
-            if ($force == false) {
+            if (!$force) {
                 $this->_error("* Site file $siteFile already exists. Use --force to drop.");
                 return false;
             }
@@ -335,20 +335,20 @@ class CakeboxExecute
         ]);
 
         // Write generated vhost configuration to file
-        if ($this->writeSystemFile($siteFile, $config) == false) {
+        if (!$this->writeSystemFile($siteFile, $config)) {
             $this->_error("Error writing virtual hosts file $siteFile");
             return false;
         }
         $this->_log("* Successfully created $siteFile");
 
         // Create symbolic link in sites-enabled
-        if ($this->createSiteSymlink($url) == false) {
+        if (!$this->createSiteSymlink($url)) {
             $this->_error("Error creating symbolic link");
             return false;
         }
 
         // Reload nginx service to effectuate changes
-        if ($this->reloadNginx() == false) {
+        if (!$this->reloadNginx()) {
             return false;
         }
         return true;
@@ -397,7 +397,7 @@ class CakeboxExecute
         }
 
         // Reload nginx service to effectuate changes
-        if ($this->reloadNginx() == false) {
+        if (!$this->reloadNginx()) {
             return false;
         }
         $this->_log("Website deleted successully");
@@ -428,12 +428,12 @@ class CakeboxExecute
 
         // drop existing databases if needed
         if (CakeboxUtility::databaseExists($database)) {
-            if ($force == false) {
+            if (!$force) {
                 $this->_error("* Database $database already exists. Use --force to drop.");
                 return false;
             }
             $this->_log("Dropping existing databases");
-            if (CakeboxUtility::dropDatabase($database) == false) {
+            if (!CakeboxUtility::dropDatabase($database)) {
                 $this->_error("Error dropping databases");
                 return false;
             }
@@ -441,7 +441,7 @@ class CakeboxExecute
 
         // create databases
         $this->_log("Creating databases");
-        if (CakeboxUtility::createDatabase($database, $username, $password) == false) {
+        if (!CakeboxUtility::createDatabasePair($database, $username, $password)) {
             $this->_error("Error creating databases");
             return false;
         }
@@ -482,7 +482,7 @@ class CakeboxExecute
         $fh->write($content);
 
         // Move the tempfile
-        if ($this->shell("mv $tempFile $file", 'root') == false) {
+        if (!$this->shell("mv $tempFile $file", 'root')) {
             $this->_error("* Error moving $tempFile to $file");
             return false;
         }
@@ -532,7 +532,7 @@ class CakeboxExecute
         }
 
         // shell `ln` command as root
-        if ($this->shell("ln -s $target $link", 'root') == false) {
+        if (!$this->shell("ln -s $target $link", 'root')) {
             $this->_error("Error creating symbolic link");
             return false;
         }
@@ -556,7 +556,7 @@ class CakeboxExecute
         }
 
         // not installed, shell installation
-        if ($this->shell("DEBIAN_FRONTEND=noninteractive apt-get install -y $package", 'root') == false) {
+        if (!$this->shell("DEBIAN_FRONTEND=noninteractive apt-get install -y $package", 'root')) {
             $this->_error("* Error installing package");
             return false;
         }
@@ -582,7 +582,7 @@ class CakeboxExecute
             "'database' => 'my_app'" => "'database' => '$database'",
             "'database' => 'test_myapp'" => "'database' => 'test_$database'"
             ]);
-            if ($result == false) {
+            if (!$result) {
                 $this->_log("Error updating config file");
                 return false;
             }
@@ -606,7 +606,7 @@ class CakeboxExecute
             $this->cbi->frameworkMeta['cakephp2']['salt'] => CakeboxUtility::getSaltCipher($coreFile),
             $this->cbi->frameworkMeta['cakephp2']['cipher'] => CakeboxUtility::getSaltCipher($coreFile)
         ]);
-        if ($res == false) {
+        if (!$res) {
             $this->_error("Error updating core file");
             return false;
         }
@@ -628,7 +628,7 @@ class CakeboxExecute
             'user' => 'cakebox',
             "'password' => 'password'" => "'password' => 'secret'"
         ]);
-        if ($result == false) {
+        if (!$result) {
             $this->_error("Error updating database file");
             return false;
         }
@@ -672,13 +672,13 @@ class CakeboxExecute
 
         // shell Percona XtraBackup job as root
         $this->_log("Starting hot backup");
-        if ($this->shell("xtrabackup --backup --target-dir=$tempFolder", 'root') == false) {
+        if (!$this->shell("xtrabackup --backup --target-dir=$tempFolder", 'root')) {
             return false;
         }
 
         // move backup from /tmp to synced folder
         $this->_log("Moving backup to Synced Folder");
-        if ($this->shell("mv $tempFolder $targetFolder", 'root') == false) {
+        if (!$this->shell("mv $tempFolder $targetFolder", 'root')) {
             return false;
         }
         return true;
@@ -706,12 +706,12 @@ class CakeboxExecute
         $template = APP . 'Template' . DS . 'Bake' . DS . "nginx-cakebox-$protocol";
 
         $this->_log("Replacing vhost $default with $template");
-        if ($this->shell("cp $template $default", 'root') == false) {
+        if (!$this->shell("cp $template $default", 'root')) {
             return false;
         }
 
         // Reload nginx service to effectuate changes
-        if ($this->reloadNginx() == false) {
+        if (!$this->reloadNginx()) {
             return false;
         }
         $this->_log("* Dashboard protocol changed successfully");

--- a/src/Shell/AppShell.php
+++ b/src/Shell/AppShell.php
@@ -112,7 +112,8 @@ class AppShell extends Shell
     */
     public function logError($message) {
         log::warning($message);
-        $this->out("<error>$message</error> <info>See /var/log/cakephp/cakebox.cli.log for details.</info>", 1, Shell::QUIET);
+        $this->out("<error>$message</error>", 1, Shell::QUIET);
+        $this->out("<info>See /var/log/cakephp/cakebox.cli.log for details.</info>");
     }
 
     /**

--- a/src/Shell/ApplicationShell.php
+++ b/src/Shell/ApplicationShell.php
@@ -4,6 +4,7 @@ namespace App\Shell;
 use App\Lib\CakeboxUtility;
 use App\Lib\CakeboxFrameworkInstaller;
 use Cake\Console\Shell;
+use Cake\Utility\Inflector;
 
 /**
  * Shell class for installing and configuring PHP framework applications.
@@ -29,7 +30,7 @@ class ApplicationShell extends AppShell
         $parser->addSubcommand('add', [
             'parser' => [
                 'description' => [
-                    __("Installs a fully working application in /home/vagrant/Apps using Nginx and MySQL.")
+                    __('Installs a fully working application in /home/vagrant/Apps using Nginx and MySQL.')
                 ],
                 'arguments' => [
                     'url' => [
@@ -55,14 +56,21 @@ class ApplicationShell extends AppShell
                         'default' => '3'
                     ],
                     'source' => [
-                        'short' => 's',
                         'help' => __('Source used to provision your own application. Provide either the Github shortname to your repository (owner/repository) or the Composer package name (e.g. cakephp/app). Framework will be autodetected.'),
+                        'required' => false
+                    ],
+                    'webroot' => [
+                        'help' => __('Webroot as to be used as your Nginx virtual host webroot directive. Required when using custom sources.'),
                         'required' => false
                     ],
                     'ssh' => [
                         'help' => __('Use SSH instead of HTTPS. Only useful in combination with out-of-the-box applications using git repositories.'),
                         'boolean' => true
-                        ]
+                    ],
+                    'repair' => [
+                        'help' => __('Repair an existing installation by installing only missing sources, databases and/or virtual hosts.'),
+                        'boolean' => true
+                    ]
                 ]
             ]
         ]);
@@ -77,49 +85,192 @@ class ApplicationShell extends AppShell
      */
     public function add($url)
     {
-        $this->logStart("Creating application http://$url");
+        if ($this->params['repair']) {
+            $this->logStart("Repairing application http://$url");
+        } else {
+            $this->logStart("Creating application http://$url");
+        }
 
         if ($url == 'default') {
             $this->exitBashError("Cannot use 'default' as <url> as this would overwrite the default Cakebox site.");
         }
 
-        # Feed the installer with required information
+        # Feed the installer with all required information
         $installer = new CakeboxFrameworkInstaller();
-        $this->out("Setting up installer");
+        $this->out('Configuring installer');
         if (!$installer->setup(array_merge( ['url' => $url], $this->params ))) {
-            $this->exitBashError("Error setting up installer.");
+            $this->exitBashError('Error setting up installer.');
         }
 
-        # Check if the target directory meets requirements for git cloning
-        # (non-existent or empty). Note: exits with success here to allow
-        # vagrant re-provisioning.
-        if (!CakeboxUtility::dirAvailable($installer->option('path'))) {
-            $this->exitBashWarning("* Skipping: target directory did not pass readiness tests.\n<info>See /var/log/cakephp/cakebox.cli.log for details.</info>");
+        # Check: custom applications require the --webroot option to prevent
+        # generating an invalid Nginx vhost preventing Nginx reload and thus
+        # breaking yaml-provisioning
+        if ($installer->option('framework_short') === 'custom' && (!isset($this->params['webroot']))) {
+            $this->exitBashError('Error: custom applications require the --webroot parameter');
         }
 
-        # Prepare the installation
-        $this->out("Preparing for installation");
-        if (!$installer->prepare()) {
-            $this->exitBashError("Error preparing for installation.");
+        # Only method-detect if target dir is available once (present and/or empty)
+        $targetDirAvailable = CakeboxUtility::dirAvailable($installer->option('path'));
+
+        # Check: stop provisioning if the target directory is not
+        # available/empty AND and we are not in --repair mode
+        if (!$targetDirAvailable && (!$this->params['repair'])) {
+            $this->exitBashError('Error: target directory ' .  $installer->option('path') . ' contains data');
         }
 
-        # Provide some feedback
-        $installerMethod = $installer->detectInstallationMethod($installer->option('source'));
-        $this->out("Please wait... $installerMethod installing " . $installer->option('framework_human') . " application");
-
-        # Install the application
-        if (!$installer->install()) {
-            $this->exitBashError("Error installing application.");
+        # ------------------------------------------------------------
+        # Create installation directory if needed
+        # ------------------------------------------------------------
+        $dirHasData = false;
+        $this->out('Creating installation directory');
+        if (!$targetDirAvailable) {
+            $dirHasData = true;
+            $this->out('* Skipping: target directory contains data');
         }
 
-        # Round up
-        $this->out("Rounding up installation");
-        if (!$installer->roundup()) {
-            $this->exitBashError("Error rounding up application.");
+        if ($targetDirAvailable && is_dir($installer->option('path'))) {
+            $this->out('* Skipping: directory already created');
         }
 
-        # Provision success message
-        $this->out("Finished installation using:");
+        if (!$targetDirAvailable && !$dirHasData) {
+            if (!$this->execute->mkVagrantDir($installer->option('path'))) {
+                $this->exitBashError('Error creating target directory ' . $installer->option('path'));
+            }
+        }
+
+        # ------------------------------------------------------------
+        # Install sources if needed
+        # ------------------------------------------------------------
+        if (!$dirHasData) {
+            $this->out(Inflector::camelize($installer->option('installation_method')) . ' installing ' . $installer->option('framework_human') . ' application sources');
+            if (!$installer->installSources()) {
+                $this->exitBashError('Error installing application sources.');
+            }
+        }
+
+        if (!$dirHasData && $installer->option('installation_method') !== 'composer') {
+            if (file_exists($installer->option('path') . DS . 'composer.json')) {
+                $this->logInfo('Composer installing detected composer.json');
+                if (!$this->execute->composerInstall($installer->option('path'))) {
+                    $this->exitBashError('Error Composer installing detected composer.json.');
+                }
+            }
+        }
+
+        # ------------------------------------------------------------
+        # Create Nginx virtual host if needed
+        # ------------------------------------------------------------
+        $this->out('Creating virtual host');
+
+        // remove existing (assumed orphaned) vhost when not in --repair mode
+        if (CakeboxUtility::vhostAvailable($url) && !$this->params['repair']) {
+            $this->out('* Removing existing (assumed orphaned) virtual host');
+            if (!$this->execute->removeSite($url)) {
+                $this->exitBashError('Error removing virtual host');
+            }
+        }
+
+        $vhostAvailable = CakeboxUtility::vhostAvailable($url);
+        $vhostEnabled = CakeboxUtility::vhostEnabled($url);
+
+        if ($vhostAvailable && $vhostEnabled) {
+            $this->out('* Skipping: virtual host already up and running');
+        }
+
+        if ($vhostAvailable && !$vhostEnabled) {
+            $this->out('* Skipping: configuration file already exists');
+        }
+
+        pr($installer->options());
+        pr($installer->option('webroot'));
+
+
+        if (!$vhostAvailable) {
+            if (!$this->execute->addSite($url, $installer->option('webroot'), true)) {
+                $this->exitBashError('Error creating virtual host');
+            } else {
+                $this->out('* Successfully created virtual host');
+            }
+        }
+
+        // recheck symlink since it could have been created above
+        if (!CakeboxUtility::vhostEnabled($url)) {
+            $this->out('* Enabling virtual host');
+            if (!$this->execute->createSiteSymlink($url)) {
+                $this->exitBashError('Error creating symbolic link');
+            }
+            if (!$this->execute->reloadNginx()) {
+                $this->exitBashError('Error reloading Nginx');
+            }
+        }
+
+        # ------------------------------------------------------------
+        # Create databases if needed
+        # ------------------------------------------------------------
+        $this->out('Creating databases');
+        $mainDatabase = $installer->option('database');
+        $testDatabase = $this->cbi->databaseMeta['test_prefix'] . $installer->option('database');
+
+        // remove existing (assumed orphaned) databases when not in --repair mode
+        if (CakeboxUtility::databaseExists($mainDatabase) && !$this->params['repair']) {
+            $this->out('* Removing existing (assumed orphaned) databases');
+            if (!CakeboxUtility::dropDatabase($mainDatabase)) {
+                $this->exitBashError("Error dropping main database $mainDatabase");
+            }
+            if (!CakeboxUtility::dropDatabase($testDatabase)) {
+                $this->exitBashError("Error dropping test database $testDatabase");
+            }
+        }
+
+        if (CakeboxUtility::databaseExists($mainDatabase)) {
+            $this->out('* Skipping: main database already exists');
+        } else {
+            if (!CakeboxUtility::createDatabase($mainDatabase, 'cakebox', 'secret', true)) {
+                $this->exitBashError('Error creating main database');
+            } else {
+                $this->out('* Successfully created main database');
+            }
+        }
+
+        if (CakeboxUtility::databaseExists($testDatabase)) {
+            $this->out('* Skipping: test database already exists');
+        } else {
+            if (!CakeboxUtility::createDatabase($testDatabase, 'cakebox', 'secret', true)) {
+                $this->exitBashError('Error creating test database');
+            } else {
+                $this->out('* Successfully created test database');
+            }
+        }
+
+        # ------------------------------------------------------------
+        # Configure permissions (for supported frameworks only)
+        # ------------------------------------------------------------
+        $this->out('Configuring permissions');
+        if (!$installer->setPermissions()) {
+            $this->exitBashError('Error setting permissions');
+        }
+
+        # ------------------------------------------------------
+        # Only update config files when not in --repair mode
+        # ------------------------------------------------------
+        $this->out('Updating configuration files');
+        if ($this->params['repair']) {
+            $this->out('* Skipping: configuration files are not updated in --repair mode');
+        } else {
+            if (!$installer->updateConfigs()) {
+                $this->exitBashError('Error updating configuration file(s)');
+            }
+        }
+
+        # ------------------------------------------------------
+        # Provide user with feedback
+        # ------------------------------------------------------
+        if ($this->params['repair']) {
+            $this->out('Application repaired using:');
+        } else {
+            $this->out('Application created using:');
+        }
+
         $options = $installer->options();
         ksort($options);
         foreach ($options as $key => $value) {
@@ -131,12 +282,10 @@ class ApplicationShell extends AppShell
             $this->out("  => Make sure to manually update your database credentials, plugins, etc.");
         }
 
-        $this->out("\nAdd the following line to your hosts file: <info>" . $this->cbi->getVmIpAddress() . " http://$url</info>\n");
-        $this->out("Installation completed successfully");
+        $this->out("\nRemember to update your hosts file with: <info>" . $this->cbi->getVmIpAddress() . " http://$url</info>\n");
+        $this->out('Installation completed successfully');
         return true;
     }
-
-
 
 
 }

--- a/webroot/js/pages/dashboard.vm.js
+++ b/webroot/js/pages/dashboard.vm.js
@@ -164,7 +164,7 @@ function loadTabCliLog() {
 
 		var tbody = $('.panel-body.clilog > table > tbody')
 		$.each( data.log, function( key, entry ) {
-		 	tbody.append('<tr><td class="nowrap">' + entry.date + '</td><td class="nowrap">' + entry.time + '</td><td class="center log-' + entry.level + '">' + entry.level + '</td><td>' + entry.message + '</td></tr>' + "\n")
+		 	tbody.append('<tr><td class="nowrap">' + entry.date + '</td><td class="nowrap">' + entry.time + '</td><td class="center log-' + entry.level_name + '">' + entry.level_name + '</td><td>' + entry.message + '</td></tr>' + "\n")
 		});
 	})
 	.done(function() {


### PR DESCRIPTION
Run cakebox application command with ``--repair`` option to install only missing application components. Will recreate any combination of the following:

+ missing sources
+ missing vhost configuration
+ missing vhost symlink (with Nginx reload)
+ missing main database
+ missing test database

### Fixes #65 

### Important 

+ The ``--repair`` option is automatically appended to yaml defined applications.
+ yaml defined applications require the ``--webroot`` parameter

```yaml
apps:
  - url: mycake3.app
    options: --webroot webroot

  - url: mycake2.app
    options: --webroot app/webroot

  - url: mylaraval5.app
    options: --webroot public
```


ps: updates Laravel installer to 5 as well