### PR TITLE
Removes logstash as default logformat from generic Nginx template

### DIFF
--- a/src/Template/Bake/vhost_nginx.ctp
+++ b/src/Template/Bake/vhost_nginx.ctp
@@ -16,7 +16,7 @@ server {
     root :webroot;
     index index.php;
 
-    access_log /var/log/nginx/:url.access.log logstash;
+    access_log /var/log/nginx/:url.access.log;
     error_log /var/log/nginx/:url.error.log;
 
     location / {


### PR DESCRIPTION
Reverting a poor design choice, user should not be forced with a non-standard Nginx logformat.