### PR TITLE
Adds a box-fix for broken Elasticsearch init script

### DIFF
--- a/src/Shell/UpdateShell.php
+++ b/src/Shell/UpdateShell.php
@@ -49,17 +49,22 @@ class UpdateShell extends AppShell
         }
 
         // Update Cakebox Commands and Dashboard
-#        if (!$this->_updateCakeboxConsole()) {
-#            $this->exitBashError();
-#        }
+        if (!$this->_updateCakeboxConsole()) {
+            $this->exitBashError();
+        }
 
         // Update CakePHP Code Sniffer
         if (!$this->_updateCakephpCodeSniffer()) {
             $this->exitBashError();
         }
 
-        // Fix HHVM configuration
-        if (!$this->_fixHhvm()) {
+        // Box fix HHVM
+        if (!$this->_boxFixHhvm()) {
+            $this->exitBashError();
+        }
+
+        // Box fix Elasticsearch
+        if (!$this->_boxFixElasticSearch()) {
             $this->exitBashError();
         }
         $this->exitBashSuccess('Self-update completed successfully');
@@ -149,7 +154,7 @@ class UpdateShell extends AppShell
      *
      * @return boolean True on success
      */
-    protected function _fixHhvm()
+    protected function _boxFixHhvm()
     {
         $this->logInfo('Updating HHVM configuration');
 
@@ -159,7 +164,7 @@ class UpdateShell extends AppShell
             return false;
         }
 
-        // Repair php.ini only once (idempotent fix)
+        // Repair php.ini only once (idempotent)
         $source = APP . 'Template' . DS . 'Bake' . DS . 'box-fix-hhvm-php-ini';
         $target = '/etc/hhvm/php.ini';
         if (md5_file($source) === md5_file($target)) {
@@ -174,6 +179,35 @@ class UpdateShell extends AppShell
 
         $this->logInfo('* Restarting service');
         $command = 'service hhvm restart';
+        if (!$this->Execute->shell($command, 'root')) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Box-fix: add missing update-rc levels for HHVM so the service
+     * automatically starts on startup + corrects default session.save_path
+     *
+     * @return boolean True on success
+     */
+    protected function _boxFixElasticsearch()
+    {
+        // Repair init script only once (idempotent)
+        $source = APP . 'Template' . DS . 'Bake' . DS . 'box-fix-elasticsearch-init';
+        $target = '/etc/init.d/elasticsearch';
+        if (md5_file($source) === md5_file($target)) {
+            return true;
+        }
+
+        $this->logInfo('Updating Elasticsearch configuration');
+        $command = "cp $source $target";
+        if (!$this->Execute->shell($command, 'root')) {
+            return false;
+        }
+
+        $this->logInfo('* Restarting service');
+        $command = 'service elasticsearch restart';
         if (!$this->Execute->shell($command, 'root')) {
             return false;
         }

--- a/src/Template/Bake/box-fix-elasticsearch-init
+++ b/src/Template/Bake/box-fix-elasticsearch-init
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+#
+# elasticsearch
+#
+### BEGIN INIT INFO
+# Provides:          elasticsearch
+# Required-Start:    $network $remote_fs $named
+# Required-Stop:     $network $remote_fs $named
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Starts elasticsearch
+# Description:       Starts elasticsearch using start-stop-daemon
+### END INIT INFO
+
+# Source networking configuration
+#
+if [ -f /etc/sysconfig/network ]; then source /etc/sysconfig/network; fi
+
+# Set limits for environments ignoring `/etc/security/limits.d`
+#
+ulimit -n 64000
+ulimit -l unlimited
+
+# Exit if networking is not up
+#
+[ "$NETWORKING" = "no" ] && exit
+
+PIDFILE='/usr/local/var/run/cakebox.pid'
+ES_INCLUDE='/usr/local/etc/elasticsearch/elasticsearch-env.sh'
+CHECK_PID_RUNNING=$(ps ax | grep 'java' | grep -e "es.pidfile=$PIDFILE" | sed 's/^\s*\([0-9]*\)\s.*/\1/')
+
+start() {
+    if [ -f $PIDFILE ]; then
+      # PIDFILE EXISTS -- ES RUNNING?
+      echo -e "PID file found in $PIDFILE"
+      es_pid="$(cat $PIDFILE)"
+      pid_running="$( ps ax | grep 'java' | grep $es_pid )"
+
+      if [ ! -z "$pid_running" ] ; then
+        # EXIT IF ES IS ALREADY RUNNING
+              echo -e "\033[31;1mPID $es_pid still alive, Elasticsearch already running...\033[0m"
+              return 1
+      fi
+    fi
+
+    echo -en "\033[1mStarting Elasticsearch...\033[0m"
+    touch $PIDFILE && chown elasticsearch $PIDFILE
+      ES_INCLUDE=$ES_INCLUDE start-stop-daemon --background --start --quiet --pidfile $PIDFILE --chuid elasticsearch --exec /usr/local/bin/elasticsearch -- -p $PIDFILE
+
+    if [ $? ]; then
+      echo -e " \e[32m[OK]\e[0m"
+    else
+      echo -e " \e[31m[FAILURE]\e[0m"
+    fi
+
+    return $?
+}
+
+stop() {
+    if [[ -f $PIDFILE ]]; then
+      echo -n -e "\033[1mStopping elasticsearch...\033[0m"
+
+      # REMOVE PIDFILE AND EXIT IF PROCESS NOT RUNNING
+      if [ ! $CHECK_PID_RUNNING ]; then
+        echo -e "\033[1mPID file found, but no matching process running?\033[0m"
+        echo    "Removing PID file..."
+        rm $PIDFILE
+        exit 0
+      fi
+
+      # KILL PROCESS
+      pid=$(cat $PIDFILE)
+      su elasticsearch -m -c "kill $(cat $PIDFILE)"
+      r=$?
+
+      # Check for process
+      timeout=0
+      while [ $(ps -p $pid | wc -l ) -gt '1' ]; do
+        echo -n '.'
+        (( timeout ++))
+        if [ $timeout -gt '30' ]; then return; fi
+        sleep 1
+      done
+
+      # Check for pidfile
+      timeout=0
+      while [ -f $PIDFILE  ]; do
+        echo -n '.'
+        (( timeout++ ))
+        if [ $timeout -gt '15' ]; then return; fi
+        sleep 1
+      done
+
+      echo;
+
+      return $r
+    else
+      echo -e "\033[1mNo PID file found -- elasticsearch not running?\033[0m"
+    fi
+}
+
+restart() {
+    stop
+    timeout=30
+    while ps aux | grep 'java' | grep -e "es.pidfile"; do
+      echo -n '.'
+      (( timeout-- ))
+      if [ $timeout -lt '1' ]; then return; fi
+      sleep 1
+    done;
+    start
+}
+
+status() {
+  # GOT PIDFILE?
+  [ -f $PIDFILE ] && pid=$(cat $PIDFILE)
+
+  # RUNNING
+  if [[ $pid && -d "/proc/$pid" ]]; then
+    version=$(curl -s 'http://localhost:9200' | ruby -rubygems -e 'require "json"; print JSON.parse(STDIN.read)["version"]["number"]')
+    echo -e "\033[1;37;46melasticsearch $version running with PID $pid\033[0m"
+    # VERBOSE
+    if [[ $pid && $1 == '-v' || $1 == '--verbose' ]]; then
+      curl -s 'http://localhost:9200/_cluster/nodes/cakebox?os&process&jvm&network&transport&settings&pretty' | \
+      ruby -rubygems -e '
+        begin
+          require "json"; h = JSON.parse(STDIN.read); id, node = h["nodes"].first;
+          def e(name, value); puts %Q|\e[1;36m#{(name.to_s+":").ljust(20)}\e[0m #{value || "N/A" rescue "N/A"}|; end
+          e "HTTP Address",  node["http_address"]
+          e "Node Name",     node["name"]
+          e "Cluster Name",  h["cluster_name"]
+          e "Started",       Time.at(node["jvm"]["start_time"].to_i/1000)
+          e "JVM",           "#{node["jvm"]["vm_name"]} (#{node["jvm"]["version"]})"
+          e "Memory Total",  node["os"]["mem"]["total"]
+          e "Open Files",    node["process"]["max_file_descriptors"]
+          e "Configuration", node["settings"]["config"]
+        rescue
+          puts "Metadata cannot be retrieved."
+        end
+      '
+    fi
+    # INCORRECT PID?
+    if [ $pid != $CHECK_PID_RUNNING ]; then
+      echo -e "\033[1;31;40m[!] Incorrect PID found in $PIDFILE: $pid\033[0m"
+      return 1
+    fi
+    return 0
+  fi
+
+  # NOT RUNNING
+  if [[ ! $pid || ! -d "/proc/$pid" ]]; then
+    echo -e "\033[1;33;40melasticsearch not running\033[0m"
+    return 3
+  fi
+
+  # STALE PID FOUND
+  if [[ ! -d "/proc/$pid" && -f $PIDFILE ]]; then
+    echo -e "\033[1;31;40m[!] Stale PID found in $PIDFILE\033[0m"
+    return 1
+  fi
+}
+
+case "$1" in
+  start)
+        start
+        ;;
+  stop)
+        stop
+        ;;
+  restart)
+        restart
+        ;;
+  status)
+        status $2
+        ;;
+  *)
+        echo $"Usage: $0 {start|stop|restart|status [-v]|}"
+        exit 1
+esac

--- a/src/Template/Bake/box-fix-hhvm-php-ini
+++ b/src/Template/Bake/box-fix-hhvm-php-ini
@@ -1,0 +1,10 @@
+; php options
+session.save_handler = files
+session.save_path = /var/lib/php5/sessions
+session.gc_maxlifetime = 1440
+
+; hhvm specific
+hhvm.log.level = Warning
+hhvm.log.always_log_unhandled_exceptions = true
+hhvm.log.runtime_error_reporting_level = 8191
+hhvm.mysql.typed_results = false


### PR DESCRIPTION
Fixes existing PID error preventing Elasticsearch service to start (as described here https://github.com/alt3/cakebox-console/issues/75) by replacing flakey ``/etc/init.d/elasticsearch`` cookbook service initialization script with a hardened version.

