### PR TITLE
Fix missing class

### DIFF
--- a/src/Shell/DatabaseShell.php
+++ b/src/Shell/DatabaseShell.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Shell;
 
+use App\Lib\CakeboxInfo;
 use App\Lib\CakeboxUtility;
 use Cake\Console\Shell;
 


### PR DESCRIPTION
The `CakeboxInfo` class is required by `DatabaseShell::listall()`.
