### PR TITLE
Fixes incorrect permissions when using --path option

### DIFF
--- a/src/Lib/CakeboxExecute.php
+++ b/src/Lib/CakeboxExecute.php
@@ -138,7 +138,7 @@ class CakeboxExecute
             return false;
         }
 
-        if (!$this->shell("chown vagrant $path -R", 'root')) {
+        if (!$this->shell("chown vagrant:vagrant $path -R", 'root')) {
             return false;
         }
 

--- a/src/Shell/ApplicationShell.php
+++ b/src/Shell/ApplicationShell.php
@@ -137,7 +137,7 @@ class ApplicationShell extends AppShell
             $this->out('* Skipping: directory already created');
         }
 
-        if (!$targetDirAvailable && !$dirHasData) {
+        if ($targetDirAvailable && !$dirHasData) {
             if (!$this->Execute->mkVagrantDir($installer->option('path'))) {
                 $this->exitBashError('Error creating target directory ' . $installer->option('path'));
             }


### PR DESCRIPTION
Fixes an incorrect condition causing errors in cases where a new application directory needs to be created in a location where the vagrant user does not have permissions.

Noticed this while playing around with the `--path` parameter.
