### PR TITLE
Fixes incorrect hosts file update instruction

### DIFF
--- a/src/Shell/ApplicationShell.php
+++ b/src/Shell/ApplicationShell.php
@@ -292,7 +292,7 @@ class ApplicationShell extends AppShell
             $this->out("  => Make sure to manually update your database credentials, plugins, etc.");
         }
 
-        $this->out("\nRemember to update your hosts file with: <info>" . $this->Info->getVmIpAddress() . " http://$url</info>\n");
+        $this->out("\nRemember to update your hosts file with: <info>" . $this->Info->getVmIpAddress() . " $url</info>\n");
         $this->exitBashSuccess('Installation completed successfully');
     }
 }

--- a/src/Shell/VhostShell.php
+++ b/src/Shell/VhostShell.php
@@ -98,7 +98,7 @@ class VhostShell extends AppShell
             $this->exitBashError('Error creating virtual host configuration file');
         }
 
-        $this->out("\nRemember to update your hosts file with: <info>" . $this->Info->getVmIpAddress() . " http://$url</info>\n");
+        $this->out("\nRemember to update your hosts file with: <info>" . $this->Info->getVmIpAddress() . " $url</info>\n");
         $this->out('Installation completed successfully');
     }
 


### PR DESCRIPTION
Suggest correct instructions for updating local hosts file after provisioning a vhost or application: 

```
ip    fqdn
```

instead of incorrect

```
ip    http://fqdn
```
