### PR TITLE
Fix for missing CakePHP tag "2.7". Switched to tag "2.x".

### DIFF
--- a/src/Lib/CakeboxInfo.php
+++ b/src/Lib/CakeboxInfo.php
@@ -74,8 +74,8 @@ class CakeboxInfo
     public $frameworkMeta = [
         'cakephp2' => [
             'installation_method' => 'git',
-            'source' => 'https://github.com/cakephp/cakephp.git -b 2.7',
-            'source_ssh' => 'git@github.com:cakephp/cakephp.git -b 2.7',
+            'source' => 'https://github.com/cakephp/cakephp.git -b 2.x',
+            'source_ssh' => 'git@github.com:cakephp/cakephp.git -b 2.x',
             'webroot' => 'app/webroot',
             'writable_dirs' => ['app/tmp'],
             'salt' => 'DYhG93b0qyJfIxfs2guVoUubWwvniR2G0FgaC9mi',

--- a/tests/TestCase/Lib/CakeboxInfoTest.php
+++ b/tests/TestCase/Lib/CakeboxInfoTest.php
@@ -68,8 +68,8 @@ class CakeboxInfoTest extends TestCase
         $expected = [
             'cakephp2' => [
                 'installation_method' => 'git',
-                'source' => 'https://github.com/cakephp/cakephp.git -b 2.7',
-                'source_ssh' => 'git@github.com:cakephp/cakephp.git -b 2.7',
+                'source' => 'https://github.com/cakephp/cakephp.git -b 2.x',
+                'source_ssh' => 'git@github.com:cakephp/cakephp.git -b 2.x',
                 'webroot' => 'app/webroot',
                 'writable_dirs' => ['app/tmp'],
                 'salt' => 'DYhG93b0qyJfIxfs2guVoUubWwvniR2G0FgaC9mi',


### PR DESCRIPTION
See issue https://github.com/alt3/cakebox/issues/67
