### PR TITLE
Fix nginx php7 fastcgi_pass

### DIFF
--- a/src/Template/Bake/vhost_nginx.ctp
+++ b/src/Template/Bake/vhost_nginx.ctp
@@ -26,7 +26,7 @@ server {
     location ~ \.php$ {
         try_files $uri =404;
         include /etc/nginx/fastcgi_params;
-        fastcgi_pass    unix:/var/run/php5-fpm.sock;
+        fastcgi_pass    unix:/var/run/php/php7.1-fpm.sock;
         fastcgi_index   index.php;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     }


### PR DESCRIPTION
502 error with the php5 file => resolved for php7.1 this way.
Do we need a switch to detect old style? Or are we now moving completely to 7.1+?