### PR TITLE
Revert "Do not run composer update as root"

### DIFF
--- a/src/Shell/UpdateShell.php
+++ b/src/Shell/UpdateShell.php
@@ -80,7 +80,7 @@ class UpdateShell extends AppShell
     {
         $this->logInfo('Self-updating Composer');
         $command = 'composer self-update';
-        if (!$this->Execute->shell($command)) {
+        if (!$this->Execute->shell($command, 'root')) {
             return false;
         }
 


### PR DESCRIPTION
Reverts alt3/cakebox-console#131 (as this breaks the initial installation).

