### PR TITLE
Revert "Do not use vagrant home when updating global composer"

### DIFF
--- a/src/Shell/UpdateShell.php
+++ b/src/Shell/UpdateShell.php
@@ -80,11 +80,7 @@ class UpdateShell extends AppShell
     {
         $this->logInfo('Self-updating Composer');
         $command = 'composer self-update';
-
-        // We MUST use the -H` addition when updating the globally installed Composer
-        // or permissions inside `/home/vagrant/.composer` will be changed to user `root`
-        // giving all sorts of trouble (https://github.com/composer/composer/issues/6602)
-        if (!$this->Execute->shell($command, 'root -H')) {
+        if (!$this->Execute->shell($command, 'root')) {
             return false;
         }
 


### PR DESCRIPTION
Reverts alt3/cakebox-console#133